### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,40 @@
 # Daps2Docker
 
-A bash wrapper for building documentation in the Daps docker container.
+Create HTML and PDF output of documents in a DAPS-compatible DocBook or
+ASCIIDoc documentation repository. This script uses Docker to save you the
+hassles of setting up a documentation toolchain.
 
-## Getting started
+## Installation
 
-TBD.
+1. Install the Docker package for your distribution. For example:
+  * OpenSUSE/SLES: `sudo zypper install docker`
+  * Fedora/RHEL: `sudo dnf install docker`
+  * Ubuntu/Debian: `sudo apt install docker.io`
+2. Clone this repository: `git clone https://github.com/openSUSE/daps2docker`
 
-## Prerequisites
+## Usage
 
-TBD.
+### First-Run Prerequisites
 
-## Installing
+On the first run, Docker needs to download a container with an installation
+of DAPS on openSUSE Leap. This means, you need:
 
-TBD.
+* Make sure you have at least 1 GB of space on your root partition left
+* Make sure you internet access
+
+### Running
+
+1. Clone a DAPS-compatible documentation repository.
+2. The `DC-` files in the documentation repository correspond to documents.
+  Check which `DC-` files you want to build.
+3. Run the script from the cloned script repository. You can choose between two
+  modes:
+  * To build all DC files: `./daps2docker.sh /PATH/TO/DOC-DIR`
+  * To build a single DC file: `./daps2docker.sh /PATH/TO/DC-FILE`
+  By default, the script will create PDF and HTML output, but there are
+  more formats available: See the output of `./daps2docker.sh --help`.
+4. You may have to enter the root password to allow starting the Docker service
+  or a Docker container.
+
+When it is done, the script will tell you where it copied the output documents.
+Now you just need to take a look!

--- a/daps2docker.sh
+++ b/daps2docker.sh
@@ -1,8 +1,8 @@
 #! /bin/sh
 
 # daps2docker
-# A script which takes a daps build directory, loads it into a DAPS docker
-# container builds it, and returns the directroy with the built docus.
+# A script which takes a DAPS build directory, loads it into a DAPS docker
+# container, builds it, and returns the directory with the built documentation.
 
 outdir=$(mktemp -d -p /tmp daps2docker-XXXXXX)
 mydir=$(pwd $0)

--- a/docker_helper.sh
+++ b/docker_helper.sh
@@ -1,0 +1,119 @@
+#! /bin/sh
+
+# daps2docker Docker Helper
+# This script runs all the Docker-related commands, having this in a separate
+# scripts makes it easier to run with root privileges
+
+# $1 - name of original non-privileged user
+# $2 - input dir
+# $3 - output dir
+# $4 - formats to build, comma-separated
+# $5 .. $x - DC files to build
+
+function error_exit() {
+    # $1 - message string
+    # $2 - error code (optional)
+    echo "$1"
+    [[ $2 ]] && exit $2
+    exit 1
+}
+
+user=$(whoami)
+user_change=1
+if [[ $1 == '!!no-user-change' ]]
+  then
+    user_change=0
+  else
+    user=$1
+fi
+shift
+
+outdir=$1
+shift
+
+dir=$1
+shift
+
+formats=$(echo "$1" | sed 's/,/ /g')
+shift
+
+dc_files=$*
+
+# PAGER=cat means we avoid calling "less" here which would make it interactive
+# and that is the last thing we want.
+# FIXME: I am sure there is a better way to do this.
+PAGER=cat systemctl status docker.service >/dev/null 2>/dev/null
+service_status=$?
+if [ $service_status -eq 3 ]
+  then
+    if [[ ! $(whoami) == 'root' ]]
+      then
+        "Docker service is not running. Give permission to start it."
+        sudo systemctl start docker.service
+      else
+        systemctl start docker.service
+    fi
+  elif [ $service_status -gt 0 ]
+    then
+    error_exit "Issue with Docker service. Check 'systemctl status docker' yourself."
+fi
+
+# spawn a Daps container
+docker run -d susedoc/ci:openSUSE-42.3 tail -f /dev/null
+
+# check if spawn was successful
+if [ ! $? -eq 0 ]
+  then
+    error_exit "Error spawning container."
+fi
+
+# first get the name of the container, then get the ID of the Daps container
+docker_id=$(docker ps -aqf "ancestor=susedoc/ci:openSUSE-42.3" | head -1)
+echo "Got Container ID: $docker_id"
+
+# copy the Daps directory to the docker container
+temp_dir=/daps_temp
+docker exec $docker_id rm -rf $temp_dir 2>/dev/null
+docker exec $docker_id mkdir $temp_dir 2>/dev/null
+
+# only copy the stuff we want -- not sure whether that saves any time, but it
+# avoids copying the build dir (which avoids confusing users if there is
+# something in it already: after the build we're copying the build dir back to
+# the host and then having additional stuff there is ... confusing)
+for subdir in images adoc xml
+  do
+    [[ -d $dir/$subdir ]] && docker cp $dir/$subdir $docker_id:$temp_dir
+done
+for dc in $dir/DC-*
+  do
+    [[ -f $dc ]] && docker cp $dc $docker_id:$temp_dir
+done
+
+echo "Package versions in container:"
+for dep in daps libxslt-tools libxml2-tools xmlgraphics-fop docbook-xsl-stylesheets docbook5-xsl-stylesheets suse-xsl-stylesheets hpe-xsl-stylesheets geekodoc novdoc
+  do
+    echo -n '  - '
+    docker exec $docker_id rpm -qi $dep | head -2 | awk '{print $3;}' | tr '\n' ' '
+    echo ''
+done
+
+# build HTML and PDF
+for dc_file in $dc_files
+  do
+    for format in $formats
+      do
+        [[ $format == 'single-html' ]] && format='html --single'
+        docker exec $docker_id daps -d $temp_dir/$dc_file $format
+    done
+done
+
+# copy the finished product back to the host
+mkdir -p $outdir 
+docker cp $docker_id:$temp_dir/build/. $outdir
+[[ user_change -eq 1 ]] && chown -R $user $outdir
+
+# stop the Daps container
+docker stop $docker_id >/dev/null 2>/dev/null
+
+# we won't ever use the same container again, so remove the container's files
+docker rm $docker_id >/dev/null 2>/dev/null


### PR DESCRIPTION
A lot of improvements (fixes #2, #4)

Sorry for the big commit (relative to project size anyway).

Improvements:

* check whether Docker is actually installed (#4)
* working check for whether there are DC files (our check would fail because `-f` can't deal with globs like `DC-*`, but we'd continue anyway, because there was no `exit` after the check failed) 
* actually exit when we promise (we'd previously just print an error message and then continue to run anyway)
* level up with sudo if we have to (unfortunately that required a
  second script) (#4) - Docker always runs as root, the `docker` client only runs for user in the group `docker` and for root 
* build all the DC files we promise to build (there was previously no loop to do this, I am not even sure how it worked previously if there was more than one DC file in a dir).
* allow building individual DC files (much like regular DAPS)
* allow selecting which formats to build (via an extra parameter)
* copy output to /tmp of the host and print where we copied to (#2)
* clean up Docker container after use (`docker rm ...`)
* add a rudimentary help (when there is no `$1` or when it is --help/-h)
* REAMDE fixes