### PR TITLE
Add podman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ For `Docker`:
 
 For `Podman`:
 
-* See [Official documentation](https://github.com/containers/libpod/blob/master/install.md)
+* The minimum required version is `1.1.0`.
+For installation see [Official documentation](https://github.com/containers/libpod/blob/master/install.md)
 
 
 2. Clone this repository: `git clone https://github.com/openSUSE/daps2docker`

--- a/README.md
+++ b/README.md
@@ -1,23 +1,43 @@
 # Daps2Docker
 
 Create HTML and PDF output of documents in a DAPS-compatible DocBook or
-ASCIIDoc documentation repository. This script uses Docker to save you the
-hassles of setting up a documentation toolchain.
+ASCIIDoc documentation repository. This script uses Docker (default) or Podman
+to save you the hassles of setting up a documentation toolchain.
 
 ## Installation
 
-1. Install the Docker package for your distribution. For example:
-   *  OpenSUSE/SLES: `sudo zypper install docker`
-   *  Fedora/RHEL: `sudo dnf install docker`
-   *  Ubuntu/Debian: `sudo apt install docker.io`
+1. Install the package for your distribution.
+
+For `Docker`:
+
+*  OpenSUSE/SLES: `sudo zypper install docker`
+*  Fedora/RHEL: `sudo dnf install docker`
+*  Ubuntu/Debian: `sudo apt install docker.io`
+
+
+For `Podman`:
+
+* See [Official documentation](https://github.com/containers/libpod/blob/master/install.md)
+
+
 2. Clone this repository: `git clone https://github.com/openSUSE/daps2docker`
 
 ## Usage
 
+By default, `daps2docker` uses `docker` as a container engine.
+In order to use `podman`, it is required to export the environment
+variable `CONTAINER_ENGINE=podman`:
+
+```console
+$ export CONTAINER_ENGINE=podman
+```
+
 ### First-Run Prerequisites
 
-On the first run, Docker needs to download a container with an installation
-of DAPS on openSUSE Leap. This means, you need:
+On the first run, Docker/Podman needs to download a container
+with an installation of DAPS on openSUSE Leap.
+
+This means, you need:
 
 *  Make sure you have at least 1.5 GB of space on your root partition left
 *  Make sure you have internet access
@@ -33,8 +53,9 @@ of DAPS on openSUSE Leap. This means, you need:
    *  To build a single DC file: `./daps2docker.sh /PATH/TO/DC-FILE`
    By default, the script will create PDF and HTML output, but there are
    more formats available: See the output of `./daps2docker.sh --help`.
-4. You may have to enter the root password to allow starting the Docker service
-   or a Docker container.
+4. For `docker`, you may have to enter the root password to allow starting
+   the Docker service. This also apply to start/stop containers independently
+   of the container engine.
 
 When it is done, the script will tell you where it copied the output documents.
 Now you just need to take a look!

--- a/daps2docker.sh
+++ b/daps2docker.sh
@@ -3,9 +3,10 @@
 # daps2docker
 # Author: Fabian Baumanis
 #
-# A script which takes a DAPS build directory, loads it into a DAPS docker
-# container, builds it, and returns the directory with the built documentation.
+# A script which takes a DAPS build directory, loads it into a DAPS container,
+# builds it, and returns the directory with the built documentation.
 
+container_engine=${CONTAINER_ENGINE:-docker}
 me=$(test -L $(realpath $0) && readlink $(realpath $0) || echo $(realpath $0))
 mydir=$(dirname $me)
 
@@ -23,7 +24,7 @@ error_exit() {
 }
 
 app_help() {
-  echo "daps2docker / Build DAPS documentation in a Docker container."
+  echo "daps2docker / Build DAPS documentation in a container."
   echo "Usage:"
   echo "  (1) $0 [DOC_DIR] [FORMAT]"
   echo "      # Build all DC files in DOC_DIR"
@@ -35,8 +36,8 @@ app_help() {
     then
       echo ""
       echo "Extended options:"
-      echo "  D2D_IMAGE=[DOCKER_IMAGE_ID] $0 [...]"
-      echo "      # Use the Docker image with the given ID instead of the default."
+      echo "  D2D_IMAGE=[CONTAINER_IMAGE_ID] $0 [...]"
+      echo "      # Use the container image with the given ID instead of the default."
       echo "      # Note that the specified image must be available locally already."
   else
       echo ""
@@ -44,10 +45,10 @@ app_help() {
   fi
 }
 
-which docker >/dev/null 2>/dev/null
+which $container_engine >/dev/null 2>/dev/null
 if [ $? -gt 0 ]
   then
-    error_exit "Docker is not installed. Install the 'docker' package of your distribution."
+    error_exit "$container_engine is not installed. Install the '$container_engine' package of your distribution."
 fi
 
 if [ $# -eq 0 ] || [[ $1 == '--help' ]] || [[ $1 == '-h' ]]
@@ -109,32 +110,36 @@ fi
 echo "Building formats: $formats"
 formats=$(echo "$formats" | sed 's/ /,/')
 
-# PAGER=cat means we avoid calling "less" here which would make it interactive
-# and that is the last thing we want.
-# FIXME: I am sure there is a better way to do this.
-PAGER=cat systemctl status docker.service >/dev/null 2>/dev/null
-service_status=$?
-if [ $service_status -eq 3 ]
-  then
-    if [[ ! $(whoami) == 'root' ]]
-      then
-        echo "Docker service is not running. Give permission to start it."
-        sudo systemctl start docker.service
-      else
-        systemctl start docker.service
-    fi
-  elif [ $service_status -gt 0 ]
+if [[ "$container_engine" == "docker" ]]; then
+  # PAGER=cat means we avoid calling "less" here which would make it interactive
+  # and that is the last thing we want.
+  # FIXME: I am sure there is a better way to do this.
+  PAGER=cat systemctl status docker.service >/dev/null 2>/dev/null
+  service_status=$?
+  if [ $service_status -eq 3 ]
     then
-    error_exit "Issue with Docker service. Check 'systemctl status docker' yourself."
+      if [[ ! $(whoami) == 'root' ]]
+        then
+          echo "Docker service is not running. Give permission to start it."
+          sudo systemctl start docker.service
+        else
+          systemctl start docker.service
+      fi
+    elif [ $service_status -gt 0 ]
+      then
+      error_exit "Issue with Docker service. Check 'systemctl status docker' yourself."
+  fi
 fi
 
 # Find out if we need elevated privileges (very likely, as that is the default)
-if [[ $(getent group docker | grep "\b$(whoami)\b" 2>/dev/null) ]]
+if [[ $(getent group docker | grep "\b$(whoami)\b" 2>/dev/null) || $EUID -eq 0 ]]
   then
-    $mydir/d2d_runner.sh -o="$outdir" -i="$dir" -f="$formats" -c="$containername" -u="$autoupdate" $dc_files
+    $mydir/d2d_runner.sh -e="$container_engine" -o="$outdir" -i="$dir" -f="$formats" -c="$containername" -u="$autoupdate" $dc_files
   else
-    echo "Your user account is not part of the group 'docker'. Docker needs to be run as root."
-    sudo $mydir/d2d_runner.sh -s=$(whoami) -o="$outdir" -i="$dir" -f="$formats" -c="$containername" -u="$autoupdate" $dc_files
+    if [[ "$container_engine" == "docker" ]]; then
+      echo "Your user account is not part of the group 'docker'. Docker needs to be run as root."
+    fi
+    sudo $mydir/d2d_runner.sh -e="$container_engine" -s=$(whoami) -o="$outdir" -i="$dir" -f="$formats" -c="$containername" -u="$autoupdate" $dc_files
 fi
 if [[ -d "$outdir" ]] && [[ -f "$outdir/filelist" ]]
   then


### PR DESCRIPTION
`Podman` is more and more used inside the openSUSE community.

This PR does not touch the logic, the outputs and the name of the files in order not to break any CI integration. I only changed a couple of variable/functions name to make them container engine agnostic.

In order to use `podman`, a user just has to export `CONTAINER_ENGINE=podman`.