### PR TITLE
Fix link to the doc-ci repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ Take a look!
 * For the container image itself, see
   [Docker Hub](https://hub.docker.com/r/susedoc/ci).
 * For the container definition, see
-  [the doc-ci repository](https://github.com/openSUSE/doc-ci/tree/develop/build-docker-ci).
+  [the doc-ci repository](https://github.com/openSUSE/doc-ci/tree/master/build-docker-ci).


### PR DESCRIPTION
Changes the link from non-existing `develop` branch to `master`.