### PR TITLE
Replace the deprecated default container

### DIFF
--- a/config
+++ b/config
@@ -49,4 +49,4 @@ formats="validate,bigfile,html,pdf"
 container_engine="docker"
 
 # The default container to use
-containername="susedoc/ci:latest"
+containername="registry.opensuse.org/documentation/containers/containers/opensuse-daps-toolchain:latest"


### PR DESCRIPTION
The daps toolchain container is now hosted on registry.opensuse.org