### PR TITLE
Fix broken doc-ci referenced link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,4 @@ Take a look!
 * For the container image itself, see
   [Docker Hub](https://hub.docker.com/r/susedoc/ci).
 * For the container definition, see
-  [the doc-ci repository](https://github.com/openSUSE/doc-ci/tree/develop/build-docker-ci).
+  [the doc-ci repository](https://github.com/openSUSE/doc-ci/tree/gha-workflow-example).


### PR DESCRIPTION
The doc-ci referenced branch is no longer accessible and is shifted to https://github.com/openSUSE/doc-ci/tree/gha-workflow-example. As a result the link opens to a '404 - page not found' error!